### PR TITLE
Update to new Kindle for PC App

### DIFF
--- a/kindle_notes_to_md.py
+++ b/kindle_notes_to_md.py
@@ -49,14 +49,14 @@ class Kindle_notes:
     # parse an input HTML file
 
     # read the file to a string
-    with open(html_file, 'r') as fp:
+    with open(html_file, 'r', encoding='utf8') as fp:
       htmls = fp.read()
 
     # parse the string
     soup = BeautifulSoup(htmls, 'html.parser')
 
     # go through all the relevant parts
-    all_divs = soup.find_all('div')
+    all_divs = soup.select('[class]')
 
     # this gets built up repeatedly over several iterations of the below loop,
     # then added to the chapter notes
@@ -69,7 +69,7 @@ class Kindle_notes:
       c = div['class'][0]
 
       try:
-        div_contents = div.string.strip()
+        div_contents = div.get_text().strip().replace(u' \xa0', '')
       except AttributeError as e:
         # This happens, but we handle it as appropriate elsewhere
         # WARN("Couldn't strip contents of {}".format(c))
@@ -183,7 +183,7 @@ class Kindle_notes:
 
     # WARN("TODO: check if the file exists and handle as appropriate")
 
-    with open(outfile, 'w') as fp:
+    with open(outfile, 'w', encoding='utf8') as fp:
       fp.write(md)
 
     INFO("Wrote the output to {}".format(outfile), LOG_COLORS['GREEN'])


### PR DESCRIPTION
New Kindle to PC app saves HTML file with h2', 'h3' tags instead of using 'div', hence I replaced find_all('div') with select('[class]') resulting in getting all elements with 'class' attribute

I also set utf8 encoding for opening HTML and saving md file (Polish characters caused "CRITICAL Exception: 'charmap' codec can't decode byte X in position Y: character maps to <undefined> error".

Additionally I noticed that div.string returns None, so I replaced with proper .get_text().
I am also removing \xa0 characters which added redundant spaces.