### PR TITLE
Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.html
 *.md
+.idea/

--- a/kindle_notes_to_md.py
+++ b/kindle_notes_to_md.py
@@ -7,6 +7,7 @@ import argparse
 from collections import OrderedDict
 import sys
 import traceback
+import re
 
 from bs4 import BeautifulSoup
 
@@ -140,6 +141,9 @@ class Kindle_notes:
 
       # now we have the highlight or note text
       elif c == 'noteText':
+
+        # remove duplicated Location text appended due to misplaced </div> that new Kindle App adds in noteHeading
+        div_contents = re.sub('\nHighlight (.*) - Location [0-9]*', '', div_contents)
 
         # save as either Highlight or Note, as appropriate
         if last_note_type == 'Highlight':

--- a/kindle_notes_to_md.py
+++ b/kindle_notes_to_md.py
@@ -4,244 +4,240 @@ Convert an HTML file of book notes exported from an Amazon Kindle
 to a Markdown document
 '''
 import argparse
-from collections import OrderedDict
+import os
 import sys
 import traceback
-import os
+from collections import OrderedDict
+
 import pyperclip
-
 from bs4 import BeautifulSoup
-
 from eglogging import *
+
 logging_load_human_config()
 
 
 class Note:
-  # highlight, possibly including a note
-  def __init__(self):
-    self.text     = ''   # the book text that was highligthed
-    self.note     = ''   # any note I added
-    self.source   = ''   # info about the source of this note (location etc.)
-    self.location = None # int Location as given by Kindle
+    # highlight, possibly including a note
+    def __init__(self):
+        self.text = ''  # the book text that was highlighted
+        self.note = ''  # any note I added
+        self.source = ''  # info about the source of this note (location etc.)
+        self.location = None  # int Location as given by Kindle
 
 
+class ChapterNotes:
+    def __init__(self, chapter_title=''):
+        self.title = chapter_title  # name of this chapter
+        self.notes = OrderedDict()  # Location (int) -> [Note]
 
-class Chapter_notes:
-  def __init__(self, chapter_title = ''):
-    self.title = chapter_title # name of this chapter
-    self.notes = OrderedDict() # Location (int) -> [Note]
-
-  def get_last_note(self):
-    # returns the most recently-added note
-    return self.notes[next(reversed(self.notes))]
-
+    def get_last_note(self):
+        # returns the most recently-added note
+        return self.notes[next(reversed(self.notes))]
 
 
-class Kindle_notes:
-  def __init__(self):
-    self.book_title = ''
-    self.author     = ''
+class KindleNotes:
+    def __init__(self):
+        self.book_title = ''
+        self.author = ''
 
-    # list of Chapter_notes
-    self.chapter_notes = []
+        # list of Chapter_notes
+        self.chapter_notes = []
 
+    def parse_file(self, html_file: str):
+        # parse an input HTML file
 
+        # read the file to a string
+        with open(html_file, 'r', encoding='utf8') as fp:
+            htmls = fp.read()
 
-  def parse_file(self, html_file: str):
-    # parse an input HTML file
+        # parse the string
+        soup = BeautifulSoup(htmls, 'html.parser')
 
-    # read the file to a string
-    with open(html_file, 'r', encoding='utf8') as fp:
-      htmls = fp.read()
+        # go through all the relevant parts
+        all_divs = soup.select('[class]')
 
-    # parse the string
-    soup = BeautifulSoup(htmls, 'html.parser')
+        # this gets built up repeatedly over several iterations of the below loop,
+        # then added to the chapter notes
+        wip_note = None
 
-    # go through all the relevant parts
-    all_divs = soup.select('[class]')
+        last_note_type = ''  # should be either Highlight or Note
 
-    # this gets built up repeatedly over several iterations of the below loop,
-    # then added to the chapter notes
-    wip_note = None
+        for div in all_divs:
+            # the class of the div
+            c = div['class'][0]
 
-    last_note_type = '' # should be either Highlight or Note
-
-    for div in all_divs:
-      # the class of the div
-      c = div['class'][0]
-
-      try:
-        div_contents = div.get_text().strip().replace(u' \xa0', '')
-      except AttributeError as e:
-        # This happens, but we handle it as appropriate elsewhere
-        # WARN("Couldn't strip contents of {}".format(c))
-        div_contents = None
-
-      # handle title and author
-      if c == 'bookTitle':
-        self.book_title = div_contents
-      elif c == 'authors':
-        self.author = div_contents
-
-      # start of chapter
-      elif c == 'sectionHeading':
-        # add a new empty chapter
-        self.chapter_notes.append(Chapter_notes(div_contents))
-
-      # Notes look like so:
-      # <div class="noteHeading">
-      # Highlight (<span class="highlight_yellow">yellow</span>) -  Location 180
-      # </div>
-      # <div class="noteText">
-      # Product management is a strange role.
-      # </div>
-      # <div class="noteHeading">
-      # Note -  Location 180
-      # </div>
-      # <div class="noteText">
-      # Strange roles are for strange people!
-      # </div>
-      elif c == 'noteHeading':
-        try:
-          # first figure out what location this note/highlight is for
-          source = ' '.join(div.stripped_strings)
-          location = int(source.split()[-1])
-          # INFO("Location {}".format(location))
-
-          # the first word of the div should be either Highlight or Note
-          last_note_type = source.split()[0]
-
-          # if it's a "Note", add it to the previous highlight
-          # because that's what the note is about
-          # sometimes the exported notes have slightly different locations for
-          #   highlights and notes on long passages
-          if last_note_type == 'Note':
             try:
-              wip_note = self.chapter_notes[-1].get_last_note()
-            except Exception as e:
-              WARN("Exception getting last-inserted note: {}".format(e))
-              wip_note = None
+                div_contents = div.get_text().strip().replace(u' \xa0', '')
+            except AttributeError as e:
+                # This happens, but we handle it as appropriate elsewhere
+                # WARN("Couldn't strip contents of {}".format(c))
+                div_contents = None
 
-          # make a new note for Highlights
-          else:
-            wip_note = None
+            # handle title and author
+            if c == 'bookTitle':
+                self.book_title = div_contents
+            elif c == 'authors':
+                self.author = div_contents
 
-          # if we don't have a note, create one
-          if wip_note is None:
-            wip_note = Note()
-            wip_note.location = location
+            # start of chapter
+            elif c == 'sectionHeading':
+                # add a new empty chapter
+                self.chapter_notes.append(ChapterNotes(div_contents))
 
-            # this happens twice for notes, but that's OK
-            wip_note.source = ' '.join(div.stripped_strings)
+            # Notes look like so:
+            # <div class="noteHeading">
+            # Highlight (<span class="highlight_yellow">yellow</span>) -  Location 180
+            # </div>
+            # <div class="noteText">
+            # Product management is a strange role.
+            # </div>
+            # <div class="noteHeading">
+            # Note -  Location 180
+            # </div>
+            # <div class="noteText">
+            # Strange roles are for strange people!
+            # </div>
+            elif c == 'noteHeading':
+                # first figure out what location this note/highlight is for
+                source = ' '.join(div.stripped_strings)
 
-            # add this WIP note to the dictionary
-            self.chapter_notes[-1].notes[location] = wip_note
+                try:
+                    location = int(source.split()[-1])
+                    # INFO("Location {}".format(location))
 
-        except Exception as e:
-          WARN("Couldn't figure out location from {}: {}".format(source, e))
+                    # the first word of the div should be either Highlight or Note
+                    last_note_type = source.split()[0]
 
-      # now we have the highlight or note text
-      elif c == 'noteText':
+                    # if it's a "Note", add it to the previous highlight
+                    # because that's what the note is about
+                    # sometimes the exported notes have slightly different locations for
+                    #   highlights and notes on long passages
+                    if last_note_type == 'Note':
+                        try:
+                            wip_note = self.chapter_notes[-1].get_last_note()
+                        except Exception as e:
+                            WARN("Exception getting last-inserted note: {}".format(e))
+                            wip_note = None
 
-        # remove duplicated Location text appended due to misplaced </div> that new Kindle App adds in noteHeading
-        div_contents = div_contents.split('\n')[0]
+                    # make a new note for Highlights
+                    else:
+                        wip_note = None
 
-        # save as either Highlight or Note, as appropriate
-        if last_note_type == 'Highlight':
-          wip_note.text = div_contents
+                    # if we don't have a note, create one
+                    if wip_note is None:
+                        wip_note = Note()
+                        wip_note.location = location
 
-        elif last_note_type == 'Note':
-          wip_note.note = div_contents
+                        # this happens twice for notes, but that's OK
+                        wip_note.source = ' '.join(div.stripped_strings)
 
-  def output_md(self, args):
+                        # add this WIP note to the dictionary
+                        self.chapter_notes[-1].notes[location] = wip_note
 
-    # title & author
-    md =  "- Meta:\n"
-    md += "  - title: {}\n".format(self.book_title)
-    md += "  - author: {}\n".format(self.author)
-    md += "  - tags: #Books\n"
+                except Exception as e:
+                    WARN("Couldn't figure out location from {}: {}".format(source, e))
 
-    # all the highlights
-    md += "- # Raw Highlights & Notes:\n"
+            # now we have the highlight or note text
+            elif c == 'noteText':
 
-    # for each chapter...
-    for chapter in self.chapter_notes:
-      # add a new heading 1 bullet with the chapter title
-      md += "  - ## {}\n".format(chapter.title)
+                # fix a result of a misplaced </div> that new Kindle App (1.38.0) adds in noteHeading
+                # should work fine too, when Amazon will fix their app (split will just return single elem list)
+                div_contents = div_contents.split('\n')[0]
 
-      # for each note in the chapter...
-      for location in chapter.notes:
-        note = chapter.notes[location]
+                # save as either Highlight or Note, as appropriate
+                if last_note_type == 'Highlight':
+                    wip_note.text = div_contents
 
-        # add the highlighted text
-        md += "    - {}\n".format(note.text)
+                elif last_note_type == 'Note':
+                    wip_note.note = div_contents
 
-        # if there is a note, add it in bold
-        if note.note != '':
-          md += "      - **{}**\n".format(note.note)
+    def output_md(self, args):
 
-        if (args.location):
-          # add the source of the text
-          md += "      - {}\n".format(note.source)
+        # title & author
+        md = "- Meta:\n"
+        md += "  - title: {}\n".format(self.book_title)
+        md += "  - author: {}\n".format(self.author)
+        md += "  - tags: #Books\n"
 
-    # WARN("TODO: check if the file exists and handle as appropriate")
+        # all the highlights
+        md += "- # Raw Highlights & Notes:\n"
 
-    if args.clipboard:
-      pyperclip.copy(md)
+        # for each chapter...
+        for chapter in self.chapter_notes:
+            # add a new heading 1 bullet with the chapter title
+            md += "  - ## {}\n".format(chapter.title)
 
-      INFO("Copied the output to clipboard", LOG_COLORS['GREEN'])
-    else:
-      # write the markdown file
-      with open(args.output, 'w', encoding='utf8') as fp:
-        fp.write(md)
+            # for each note in the chapter...
+            for location in chapter.notes:
+                note = chapter.notes[location]
 
-      INFO("Wrote the output to {}".format(args.output), LOG_COLORS['GREEN'])
+                # add the highlighted text
+                md += "    - {}\n".format(note.text)
 
+                # if there is a note, add it in bold
+                if note.note != '':
+                    md += "      - **{}**\n".format(note.note)
 
-  def copy_to_clipboard(self):
-    """Copy result directly into clipboard"""
+                if args.location:
+                    # add the source of the text
+                    md += "      - {}\n".format(note.source)
+
+        # WARN("TODO: check if the file exists and handle as appropriate")
+
+        if args.clipboard:
+            pyperclip.copy(md)
+
+            INFO("Copied the output to clipboard", LOG_COLORS['GREEN'])
+        else:
+            # write the markdown file
+            with open(args.output, 'w', encoding='utf8') as fp:
+                fp.write(md)
+
+            INFO("Wrote the output to {}".format(args.output), LOG_COLORS['GREEN'])
+
+    def copy_to_clipboard(self):
+        """Copy result directly into clipboard"""
+
 
 def parse_command_line_args():
+    description = "Convert an HTML file of book notes exported from an Amazon " \
+                  "Kindle to a Markdown document "
+    parser = argparse.ArgumentParser(description=description)
 
-  description = "Convert an HTML file of book notes exported from an Amazon " \
-                "Kindle to a Markdown document "
-  parser = argparse.ArgumentParser(description = description)
+    # positinal input argument
+    parser.add_argument('input',
+                        help='Input HTML file')
 
-  # positinal input argument
-  parser.add_argument('input',
-                      help='Input HTML file')
+    parser.add_argument('--location',
+                        action=argparse.BooleanOptionalAction,
+                        default=True,
+                        help='Whether to export location of notes/highlights')
 
-  parser.add_argument('--location',
-                      action=argparse.BooleanOptionalAction,
-                      default=True,
-                      help='Whether to export location of notes/highlights')
+    parser.add_argument('-c', '--clipboard',
+                        action='store_true',
+                        help='Use to export .md directly to clipboard instead of file')
 
-  parser.add_argument('-c', '--clipboard',
-                      action='store_true',
-                      help='Use to export .md directly to clipboard instead of file')
+    parser.add_argument('-o', '--output',
+                        default='',
+                        help='File to which to save the Markdown document')
 
-  parser.add_argument('-o', '--output',
-                      default='',
-                      help='File to which to save the Markdown document')
+    args = parser.parse_args()
 
-  args = parser.parse_args()
+    # if no output passed, output .md file next to original one
+    args.output = os.path.splitext(args.input)[0] + '.md'
 
-  # if no output passed, output .md file next to original one
-  args.output = os.path.splitext(args.input)[0] + '.md'
-
-  return args
-
+    return args
 
 
 if __name__ == '__main__':
-  try:
-    args = parse_command_line_args()
+    try:
+        args = parse_command_line_args()
 
-    notes = Kindle_notes()
-    notes.parse_file(args.input)
-    notes.output_md(args)
+        notes = KindleNotes()
+        notes.parse_file(args.input)
+        notes.output_md(args)
 
-  except Exception as ex:
-    CRITICAL("Exception: {}".format(ex))
-    traceback.print_exc()
-    sys.exit(1)
+    except Exception as ex:
+        CRITICAL("Exception: {}".format(ex))
+        traceback.print_exc()
+        sys.exit(1)

--- a/kindle_notes_to_md.py
+++ b/kindle_notes_to_md.py
@@ -7,7 +7,7 @@ import argparse
 from collections import OrderedDict
 import sys
 import traceback
-import re
+import os
 
 from bs4 import BeautifulSoup
 
@@ -211,10 +211,14 @@ def parse_command_line_args():
                       help='Whether to export location of notes/highlights')
 
   parser.add_argument('-o', '--output',
-                      default='converted.md',
+                      default='',
                       help='File to which to save the Markdown document')
 
   args = parser.parse_args()
+
+  # if no output passed, output .md file next to original one
+  args.output = os.path.splitext(args.input)[0] + '.md'
+
   return args
 
 

--- a/kindle_notes_to_md.py
+++ b/kindle_notes_to_md.py
@@ -143,7 +143,7 @@ class Kindle_notes:
       elif c == 'noteText':
 
         # remove duplicated Location text appended due to misplaced </div> that new Kindle App adds in noteHeading
-        div_contents = re.sub('\nHighlight (.*) - Location [0-9]*', '', div_contents)
+        div_contents = div_contents.split('\n')[0]
 
         # save as either Highlight or Note, as appropriate
         if last_note_type == 'Highlight':

--- a/kindle_notes_to_md.py
+++ b/kindle_notes_to_md.py
@@ -182,18 +182,19 @@ class KindleNotes:
                     # add the source of the text
                     md += "      - {}\n".format(note.source)
 
-        # WARN("TODO: check if the file exists and handle as appropriate")
-
         if args.clipboard:
             pyperclip.copy(md)
 
             INFO("Copied the output to clipboard", LOG_COLORS['GREEN'])
         else:
             # write the markdown file
-            with open(args.output, 'w', encoding='utf8') as fp:
-                fp.write(md)
+            if not os.path.exists(args.output) or args.override:
+                with open(args.output, 'w', encoding='utf8') as fp:
+                    fp.write(md)
 
-            INFO("Wrote the output to {}".format(args.output), LOG_COLORS['GREEN'])
+                INFO("Wrote the output to {}".format(args.output), LOG_COLORS['GREEN'])
+            else:
+                INFO("Could not save .md file, because it already exists. Use --override flag.", LOG_COLORS['RED'])
 
     def copy_to_clipboard(self):
         """Copy result directly into clipboard"""
@@ -216,6 +217,10 @@ def parse_command_line_args():
     parser.add_argument('-c', '--clipboard',
                         action='store_true',
                         help='Use to export .md directly to clipboard instead of file')
+
+    parser.add_argument('-y', '--override',
+                        action='store_true',
+                        help='Whether to override .md file in case if one already exists')
 
     parser.add_argument('-o', '--output',
                         default='',

--- a/kindle_notes_to_md.py
+++ b/kindle_notes_to_md.py
@@ -154,7 +154,7 @@ class Kindle_notes:
 
 
 
-  def write_to_file(self, outfile : str = 'output.md'):
+  def write_to_file(self, args):
     # write the markdown file
 
     # title & author
@@ -182,15 +182,16 @@ class Kindle_notes:
         if note.note != '':
           md += "      - **{}**\n".format(note.note)
 
-        # add the source of the text
-        md += "      - {}\n".format(note.source)
+        if (args.location):
+          # add the source of the text
+          md += "      - {}\n".format(note.source)
 
     # WARN("TODO: check if the file exists and handle as appropriate")
 
-    with open(outfile, 'w', encoding='utf8') as fp:
+    with open(args.output, 'w', encoding='utf8') as fp:
       fp.write(md)
 
-    INFO("Wrote the output to {}".format(outfile), LOG_COLORS['GREEN'])
+    INFO("Wrote the output to {}".format(args.output), LOG_COLORS['GREEN'])
 
 
 
@@ -202,11 +203,16 @@ def parse_command_line_args():
 
   # positinal input argument
   parser.add_argument('input',
-                      help = 'Input HTML file')
+                      help='Input HTML file')
+
+  parser.add_argument('--location',
+                      action=argparse.BooleanOptionalAction,
+                      default=True,
+                      help='Whether to export location of notes/highlights')
 
   parser.add_argument('-o', '--output',
-                      default = 'converted.md',
-                      help = 'File to which to save the Markdown document')
+                      default='converted.md',
+                      help='File to which to save the Markdown document')
 
   args = parser.parse_args()
   return args
@@ -219,7 +225,7 @@ if __name__ == '__main__':
 
     notes = Kindle_notes()
     notes.parse_file(args.input)
-    notes.write_to_file(args.output)
+    notes.write_to_file(args)
 
   except Exception as ex:
     CRITICAL("Exception: {}".format(ex))

--- a/kindle_notes_to_md.py
+++ b/kindle_notes_to_md.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 import sys
 import traceback
 import os
+import pyperclip
 
 from bs4 import BeautifulSoup
 
@@ -152,10 +153,7 @@ class Kindle_notes:
         elif last_note_type == 'Note':
           wip_note.note = div_contents
 
-
-
-  def write_to_file(self, args):
-    # write the markdown file
+  def output_md(self, args):
 
     # title & author
     md =  "- Meta:\n"
@@ -188,12 +186,20 @@ class Kindle_notes:
 
     # WARN("TODO: check if the file exists and handle as appropriate")
 
-    with open(args.output, 'w', encoding='utf8') as fp:
-      fp.write(md)
+    if args.clipboard:
+      pyperclip.copy(md)
 
-    INFO("Wrote the output to {}".format(args.output), LOG_COLORS['GREEN'])
+      INFO("Copied the output to clipboard", LOG_COLORS['GREEN'])
+    else:
+      # write the markdown file
+      with open(args.output, 'w', encoding='utf8') as fp:
+        fp.write(md)
+
+      INFO("Wrote the output to {}".format(args.output), LOG_COLORS['GREEN'])
 
 
+  def copy_to_clipboard(self):
+    """Copy result directly into clipboard"""
 
 def parse_command_line_args():
 
@@ -209,6 +215,10 @@ def parse_command_line_args():
                       action=argparse.BooleanOptionalAction,
                       default=True,
                       help='Whether to export location of notes/highlights')
+
+  parser.add_argument('-c', '--clipboard',
+                      action='store_true',
+                      help='Use to export .md directly to clipboard instead of file')
 
   parser.add_argument('-o', '--output',
                       default='',
@@ -229,7 +239,7 @@ if __name__ == '__main__':
 
     notes = Kindle_notes()
     notes.parse_file(args.input)
-    notes.write_to_file(args)
+    notes.output_md(args)
 
   except Exception as ex:
     CRITICAL("Exception: {}".format(ex))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4==4.9.3
 eglogging==1.1.0
 soupsieve==2.0.1
+pyperclip~=1.8.2


### PR DESCRIPTION
I added some cool functionality like copying .md content directly to clipboard and safe --override flag. Take a look at new arguments.

I also spotted a strange bug that Kindle App is making in it's newest version (1.38.0) - it misplaces </div> which resulted in duplicating Location text and Section Header text.
I marked with cursor that misplaced https://i.imgur.com/1yZIMXD.png
Anyway, when Amazon will fix this issue, this script should still work correctly, as I am just discarding additional lines by using `.split('\n')[0]`
 